### PR TITLE
CI: Hard code Intel Classic compiler versions

### DIFF
--- a/.github/workflows/intel-classic-tests.yml
+++ b/.github/workflows/intel-classic-tests.yml
@@ -54,7 +54,7 @@ jobs:
         | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
         echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-        sudo apt-get -y install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.0.0 intel-oneapi-compiler-fortran-2023.0.0 intel-oneapi-mkl-2023.0.0 intel-oneapi-openmp-2023.0.0
+        sudo apt-get -y install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.2.4 intel-oneapi-compiler-fortran-2023.2.4 intel-oneapi-mkl-2023.1.0 intel-oneapi-openmp-2023.2.4
       working-directory: /tmp
  
     - name: Instal Intel MPI

--- a/.github/workflows/intel-classic-tests.yml
+++ b/.github/workflows/intel-classic-tests.yml
@@ -54,7 +54,7 @@ jobs:
         | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
         echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-        sudo apt-get -y install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.2.4 intel-oneapi-compiler-fortran-2023.2.4 intel-oneapi-mkl-2023.1.0 intel-oneapi-openmp-2023.2.4
+        sudo apt-get -y install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.2.4 intel-oneapi-compiler-fortran-2023.2.4 intel-oneapi-mkl-2023.2.0 intel-oneapi-openmp-2023.2.4
       working-directory: /tmp
  
     - name: Instal Intel MPI

--- a/.github/workflows/intel-classic-tests.yml
+++ b/.github/workflows/intel-classic-tests.yml
@@ -54,7 +54,7 @@ jobs:
         | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
         echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-        sudo apt-get -y install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-compiler-fortran intel-oneapi-mkl intel-oneapi-openmp
+        sudo apt-get -y install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.0.0 intel-oneapi-compiler-fortran-2023.0.0 intel-oneapi-mkl-2023.0.0 intel-oneapi-openmp-2023.0.0
       working-directory: /tmp
  
     - name: Instal Intel MPI


### PR DESCRIPTION
During the github action workflow for the intel classic compilers, there appears to be a version mismatch between the intel C++ compilers and the intel fortran compilers. This was causing `ifort` to not be found after sourcing `setvars.sh` in the intel oneAPI directory. Hardcoding the package versions during installation from APT fixes the issue in my forked copy