### PR TITLE
Changed 2L to L in ScalarFieldLevel.cpp

### DIFF
--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -128,7 +128,7 @@ void ScalarFieldLevel::computeTaggingCriterion(
     const FArrayBox &current_state_diagnostics)
 {
     BoxLoops::loop(
-        FixedGridsTaggingCriterion(m_dx, m_level, 2.0 * m_p.L, m_p.center),
+        FixedGridsTaggingCriterion(m_dx, m_level, m_p.L, m_p.center),
         current_state, tagging_criterion);
 }
 void ScalarFieldLevel::specificPostTimeStep()


### PR DESCRIPTION
Upon request by Katie, I changed 2L to L in ScalarFieldLevel.cpp. The original stopped boxes from being 1:2:4 et cet., confusing a lot of people.