### PR TITLE
fix clang-format

### DIFF
--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -127,9 +127,8 @@ void ScalarFieldLevel::computeTaggingCriterion(
     FArrayBox &tagging_criterion, const FArrayBox &current_state,
     const FArrayBox &current_state_diagnostics)
 {
-    BoxLoops::loop(
-        FixedGridsTaggingCriterion(m_dx, m_level, m_p.L, m_p.center),
-        current_state, tagging_criterion);
+    BoxLoops::loop(FixedGridsTaggingCriterion(m_dx, m_level, m_p.L, m_p.center),
+                   current_state, tagging_criterion);
 }
 void ScalarFieldLevel::specificPostTimeStep()
 {


### PR DESCRIPTION
The ["change 2L to L"](https://github.com/GRTLCollaboration/GRChombo/pull/257) apparently broke the clang-format test. Fixed it in this PR.