### PR TITLE
234 issues with gauge implementation

### DIFF
--- a/Source/CCZ4/IntegratedMovingPunctureGauge.hpp
+++ b/Source/CCZ4/IntegratedMovingPunctureGauge.hpp
@@ -97,9 +97,10 @@ class IntegratedMovingPunctureGauge
     // For the IMP gauge, this function should do nothing
     template <class data_t, template <typename> class vars_t>
     inline void rhs_gauge_add_matter_terms(vars_t<data_t> &matter_rhs, 
-        const vars_t<data_t> &matter_vars, emtensor_t<data_t> emtensor, Tensor<2, data_t, 3> h_UU)
+        const vars_t<data_t> &matter_vars, Tensor<2, data_t, 3> h_UU, 
+        const emtensor_t<data_t> emtensor, const double G_Newton) const
     {          
-      // WHY -B^i in rhs.shift, in the function above?
+      // no changes as B should remain constant
     }
 };
 

--- a/Source/CCZ4/IntegratedMovingPunctureGauge.hpp
+++ b/Source/CCZ4/IntegratedMovingPunctureGauge.hpp
@@ -91,6 +91,16 @@ class IntegratedMovingPunctureGauge
             rhs.B[i] = 0.; // static, stays the same to save initial condition
         }
     }
+
+
+    // Add the matter terms to the rhs of the gauge equations
+    // For the IMP gauge, this function should do nothing
+    template <class data_t, template <typename> class vars_t>
+    inline void rhs_gauge_add_matter_terms(vars_t<data_t> &matter_rhs, 
+        const vars_t<data_t> &matter_vars, emtensor_t<data_t> emtensor, Tensor<2, data_t, 3> h_UU)
+    {          
+      // WHY -B^i in rhs.shift, in the function above?
+    }
 };
 
 #endif /* INTEGRATEDMOVINGPUNCTUREGAUGE_HPP_ */

--- a/Source/CCZ4/MovingPunctureGauge.hpp
+++ b/Source/CCZ4/MovingPunctureGauge.hpp
@@ -8,7 +8,6 @@
 
 #include "DimensionDefinitions.hpp"
 #include "Tensor.hpp"
-#include "EMTensor.hpp"
 
 /// This is an example of a gauge class that can be used in the CCZ4RHS compute
 /// class

--- a/Source/CCZ4/MovingPunctureGauge.hpp
+++ b/Source/CCZ4/MovingPunctureGauge.hpp
@@ -8,6 +8,7 @@
 
 #include "DimensionDefinitions.hpp"
 #include "Tensor.hpp"
+#include "EMTensor.hpp"
 
 /// This is an example of a gauge class that can be used in the CCZ4RHS compute
 /// class
@@ -63,6 +64,25 @@ class MovingPunctureGauge
                        m_params.shift_advec_coeff * advec.Gamma[i] +
                        rhs.Gamma[i] - m_params.eta * vars.B[i];
         }
+    }
+
+    // Add the matter terms to the rhs of the gauge equations
+    // For the MP gauge, this only changes the rhs of B through the rhs of Gamma
+    template <class data_t, template <typename> class vars_t>
+    inline void rhs_gauge_add_matter_terms(vars_t<data_t> &matter_rhs, 
+        const vars_t<data_t> &matter_vars, emtensor_t<data_t> emtensor, Tensor<2, data_t, 3> h_UU)
+    {          
+      FOR(i)
+      {
+        data_t matter_term_Gamma = 0.0;
+        FOR(j)
+        {
+            matter_term_Gamma += -16.0 * M_PI * m_G_Newton * matter_vars.lapse *
+                                 h_UU[i][j] * emtensor.Si[j];
+        }
+
+        matter_rhs.B[i] += matter_term_Gamma;
+      }
     }
 };
 

--- a/Source/CCZ4/MovingPunctureGauge.hpp
+++ b/Source/CCZ4/MovingPunctureGauge.hpp
@@ -70,14 +70,15 @@ class MovingPunctureGauge
     // For the MP gauge, this only changes the rhs of B through the rhs of Gamma
     template <class data_t, template <typename> class vars_t>
     inline void rhs_gauge_add_matter_terms(vars_t<data_t> &matter_rhs, 
-        const vars_t<data_t> &matter_vars, emtensor_t<data_t> emtensor, Tensor<2, data_t, 3> h_UU)
+        const vars_t<data_t> &matter_vars, Tensor<2, data_t, 3> h_UU, 
+        const emtensor_t<data_t> emtensor, const double G_Newton) const
     {          
       FOR(i)
       {
         data_t matter_term_Gamma = 0.0;
         FOR(j)
         {
-            matter_term_Gamma += -16.0 * M_PI * m_G_Newton * matter_vars.lapse *
+            matter_term_Gamma += -16.0 * M_PI * G_Newton * matter_vars.lapse *
                                  h_UU[i][j] * emtensor.Si[j];
         }
 

--- a/Source/Matter/MatterCCZ4RHS.impl.hpp
+++ b/Source/Matter/MatterCCZ4RHS.impl.hpp
@@ -104,7 +104,7 @@ void MatterCCZ4RHS<matter_t, gauge_t, deriv_t>::add_emtensor_rhs(
     }
 
     // Add matter contribution to RHS of gauge evolution
-    m_gauge.rhs_gauge_add_matter_terms(matter_rhs, matter_vars, emtensor, h_UU);
+    this->m_gauge.rhs_gauge_add_matter_terms(matter_rhs, matter_vars, h_UU, emtensor, m_G_Newton);
 }
 
 #endif /* MATTERCCZ4RHS_IMPL_HPP_ */

--- a/Source/Matter/MatterCCZ4RHS.impl.hpp
+++ b/Source/Matter/MatterCCZ4RHS.impl.hpp
@@ -101,8 +101,10 @@ void MatterCCZ4RHS<matter_t, gauge_t, deriv_t>::add_emtensor_rhs(
         }
 
         matter_rhs.Gamma[i] += matter_term_Gamma;
-        matter_rhs.B[i] += matter_term_Gamma;
     }
+
+    // Add matter contribution to RHS of gauge evolution
+    m_gauge.rhs_gauge_add_matter_terms(matter_rhs, matter_vars, emtensor, h_UU);
 }
 
 #endif /* MATTERCCZ4RHS_IMPL_HPP_ */


### PR DESCRIPTION
I added a function rhs_gauge_add_matter_terms in both the MovingPuncture and IntegratedMovingPuncture classes that adds the matter dependent terms to the rhs of the gauge evolution, as mandated by those specific gauges. This function is then called in MatterCCZ4RHS.impl.hpp.

Note that the function in the MP gauge repeats part of the calculation done in MatterCCZ4RHS.impl.hpp, to preserve generality in the function definition.

Note that the function in the IMP gauge is actually a void function.