### PR TITLE
moved symmetry factor to else clause in AMRReductions::norm

### DIFF
--- a/Source/BoxUtils/AMRReductions.impl.hpp
+++ b/Source/BoxUtils/AMRReductions.impl.hpp
@@ -108,6 +108,9 @@ Real AMRReductions<var_t>::norm(const Interval &a_vars,
     {
         norm /=
             pow(m_domain_volume, 1.0 / static_cast<double>(a_norm_exponent));
+    }
+    else
+    {
         norm *= static_cast<double>(m_symmetry_factor);
     }
 


### PR DESCRIPTION
The volume rescaled norm integral should not be multiplied with the symmetry factor, as noticed in the original bugfix discussion:
![image](https://github.com/user-attachments/assets/ffb85e83-582f-4a50-880d-bb5c85d6ac81)
I have moved it to the 'else' clause such that it now only is multiplied when the norm is *not* volume-weighted.