### PR TITLE
Updated BBH example for higher accuracy waveforms

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -9,7 +9,6 @@
 #include "BoxLoops.hpp"
 #include "CCZ4RHS.hpp"
 #include "ChiExtractionTaggingCriterion.hpp"
-#include "ChiPunctureExtractionTaggingCriterion.hpp"
 #include "ComputePack.hpp"
 #include "NanCheck.hpp"
 #include "NewConstraints.hpp"
@@ -19,6 +18,7 @@
 #include "SixthOrderDerivatives.hpp"
 #include "SmallDataIO.hpp"
 #include "TraceARemoval.hpp"
+#include "TwoPuncturesBoxExtractionTaggingCriterion.hpp"
 #include "TwoPuncturesInitialData.hpp"
 #include "Weyl4.hpp"
 #include "WeylExtraction.hpp"
@@ -96,8 +96,10 @@ void BinaryBHLevel::specificUpdateODE(GRLevelData &a_soln,
 
 void BinaryBHLevel::preTagCells()
 {
-    // We only use chi in the tagging criterion so only fill the ghosts for chi
-    fillAllGhosts(VariableType::evolution, Interval(c_chi, c_chi));
+    // We only use chi in the tagging criterion when punctures are not
+    // tracked, so only fill the ghosts for chi in this case
+    if (!(m_p.track_punctures))
+        fillAllGhosts(VariableType::evolution, Interval(c_chi, c_chi));
 }
 
 // specify the cells to tag
@@ -117,10 +119,10 @@ void BinaryBHLevel::computeTaggingCriterion(
 #endif /* USE_TWOPUNCTURES */
         auto puncture_coords =
             m_bh_amr.m_puncture_tracker.get_puncture_coords();
-        BoxLoops::loop(ChiPunctureExtractionTaggingCriterion(
+        BoxLoops::loop(TwoPunctureExtractionTaggingCriterion(
                            m_dx, m_level, m_p.max_level, m_p.extraction_params,
                            puncture_coords, m_p.activate_extraction,
-                           m_p.track_punctures, puncture_masses),
+                           puncture_masses),
                        current_state, tagging_criterion);
     }
     else

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -73,13 +73,15 @@ void BinaryBHLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
     if (m_p.max_spatial_derivative_order == 4)
     {
         BoxLoops::loop(CCZ4RHS<MovingPunctureGauge, FourthOrderDerivatives>(
-                           m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation, m_p.rescale_sigma),
+                           m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation,
+                           m_p.rescale_sigma),
                        a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
     }
     else if (m_p.max_spatial_derivative_order == 6)
     {
         BoxLoops::loop(CCZ4RHS<MovingPunctureGauge, SixthOrderDerivatives>(
-                           m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation, m_p.rescale_sigma),
+                           m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation,
+                           m_p.rescale_sigma),
                        a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
     }
 }

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -119,7 +119,7 @@ void BinaryBHLevel::computeTaggingCriterion(
 #endif /* USE_TWOPUNCTURES */
         auto puncture_coords =
             m_bh_amr.m_puncture_tracker.get_puncture_coords();
-        BoxLoops::loop(TwoPunctureExtractionTaggingCriterion(
+        BoxLoops::loop(TwoPuncturesBoxExtractionTaggingCriterion(
                            m_dx, m_level, m_p.max_level, m_p.extraction_params,
                            puncture_coords, m_p.activate_extraction,
                            puncture_masses),

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -73,13 +73,13 @@ void BinaryBHLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
     if (m_p.max_spatial_derivative_order == 4)
     {
         BoxLoops::loop(CCZ4RHS<MovingPunctureGauge, FourthOrderDerivatives>(
-                           m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
+                           m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation, m_p.rescale_sigma),
                        a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
     }
     else if (m_p.max_spatial_derivative_order == 6)
     {
         BoxLoops::loop(CCZ4RHS<MovingPunctureGauge, SixthOrderDerivatives>(
-                           m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
+                           m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation, m_p.rescale_sigma),
                        a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
     }
 }

--- a/Examples/BinaryBH/params_TP_48.txt
+++ b/Examples/BinaryBH/params_TP_48.txt
@@ -1,0 +1,261 @@
+# See the wiki page for an explanation of the params!
+# https://github.com/GRChombo/GRChombo/wiki/Guide-to-parameters
+# and a guide to this specific example at
+# https://github.com/GRChombo/GRChombo/wiki/Running-the-BBH-example
+
+#################################################
+# Filesystem parameters
+
+verbosity = 0
+
+# location / naming of output files
+# output_path = "" # Main path for all files. Must exist!
+chk_prefix = BinaryBHChk_
+plot_prefix = BinaryBHPlot_
+# restart_file = BinaryBHChk_000000.3d.hdf5
+
+# HDF5files are written every dt = L/N*dt_multiplier*checkpoint_interval
+checkpoint_interval = 100
+# set to 0 to turn off plot files (except at t=0 and t=stop_time)
+# set to -1 to never ever print plotfiles
+plot_interval = 10
+num_plot_vars = 3
+plot_vars = chi Weyl4_Re Weyl4_Im
+
+# subpaths - specific directories for hdf5, pout, extraction data
+# (these are created at runtime)
+hdf5_subpath = "hdf5"
+pout_subpath = "pout"
+data_subpath = "data"
+
+# change the name of output files
+# pout_prefix = "pout"
+print_progress_only_to_rank_0 = 1
+
+# ignore_checkpoint_name_mismatch = 0
+# write_plot_ghosts = 0
+
+#################################################
+# Initial Data parameters
+
+# provide 'offset' or 'center'
+
+massA = 0.48847892320123
+massB = 0.48847892320123
+
+offsetA = 0.0 6.10679 0.0
+offsetB = 0.0 -6.10679 0.0
+# centerA = 256 232 256
+# centerB = 256 250 256
+
+momentumA = -0.0841746 -0.000510846 0.0
+momentumB =  0.0841746  0.000510846 0.0
+
+#################################################
+# Grid parameters
+
+# 'N' is the number of subdivisions in each direction of a cubic box
+# 'L' is the length of the longest side of the box, dx_coarsest = L/N
+# NB - If you use reflective BC and want to specify the subdivisions and side
+# of the box were there are no symmetries, specify 'N_full' and 'L_full' instead
+# NB - if you have a non-cubic grid, you can specify 'N1' or 'N1_full',
+# 'N2' or 'N2_full' and 'N3' or 'N3_full' ( then dx_coarsest = L/N(max) )
+# NB - the N values need to be multiples of the block_factor
+N_full = 48
+L_full = 512
+
+# Maximum number of times you can regrid above coarsest level
+max_level = 9 # There are (max_level+1) grids, so min is zero
+
+# Frequency of regridding at each level and thresholds on the tagging
+# Need one for each level except the top one, ie max_level items
+# Generally you do not need to regrid frequently on every level
+# Level Regridding: 0   1   2   3   4   5   6   7   8
+regrid_interval =   0   0   1   0   0   0   0   0   0
+regrid_threshold = 0.05
+
+# Max and min box sizes
+max_box_size = 16
+min_box_size = 8
+
+# tag_buffer_size = 3
+# grid_buffer_size = 8
+# fill_ratio = 0.7
+# num_ghosts = 3
+# center = 256.0 256.0 256.0 # defaults to center of the grid
+
+#################################################
+# Boundary Conditions parameters
+
+# Periodic directions - 0 = false, 1 = true
+isPeriodic = 0 0 0
+# if not periodic, then specify the boundary type
+# 0 = static, 1 = sommerfeld, 2 = reflective
+# (see BoundaryConditions.hpp for details)
+hi_boundary = 1 1 1
+lo_boundary = 1 1 2
+
+# if reflective boundaries selected, must set
+# parity of all vars (in order given by UserVariables.hpp)
+# 0 = even
+# 1,2,3 = odd x, y, z
+# 4,5,6 = odd xy, yz, xz
+# 7     = odd xyz
+vars_parity            = 0 0 4 6 0 5 0    #chi and hij
+                         0 0 4 6 0 5 0    #K and Aij
+                         0 1 2 3          #Theta and Gamma
+                         0 1 2 3 1 2 3    #lapse shift and B
+vars_parity_diagnostic = 0 1 2 3          #Ham and Mom
+                         0 7              #Weyl
+
+# if sommerfeld boundaries selected, must select
+# asymptotic values
+num_nonzero_asymptotic_vars = 5
+nonzero_asymptotic_vars = chi h11 h22 h33 lapse
+nonzero_asymptotic_values = 1.0 1.0 1.0 1.0 1.0
+
+# if you are using extrapolating BC:
+# extrapolation_order = 1
+# num_extrapolating_vars = -1
+# extrapolating_vars =
+
+#################################################
+# Evolution parameters
+
+# dt will be dx*dt_multiplier on each grid level
+dt_multiplier = 0.25
+stop_time = 2200.0
+# max_steps = 100
+
+# Spatial derivative order (only affects CCZ4 RHS)
+max_spatial_derivative_order = 6 # can be 4 or 6
+
+nan_check = 1
+
+# Lapse evolution
+lapse_advec_coeff = 1.0
+lapse_coeff = 2.0
+lapse_power = 1.0
+
+# Shift evolution
+shift_advec_coeff = 0.0 # Usually no advection for beta
+shift_Gamma_coeff = 0.75
+eta = 1.0 # eta of gamma driver, should be of order ~1/M_ADM of spacetime
+
+# CCZ4 parameters
+formulation = 0 # 1 for BSSN, 0 for CCZ4
+kappa1 = 0.1
+kappa2 = 0.
+kappa3 = 1.
+covariantZ4 = 1 # 0: keep kappa1; 1 [default]: replace kappa1 -> kappa1/lapse
+
+# coefficient for KO numerical dissipation
+sigma = 1.0
+rescale_sigma = 1
+
+track_punctures = 1
+puncture_tracking_level = 5
+
+# calculate_constraint_norms = 0
+
+# min_chi = 1.e-4
+# min_lapse = 1.e-4
+
+#################################################
+# Extraction parameters
+
+# extraction_center = 256 256 256 # defaults to center
+activate_extraction = 1
+num_extraction_radii = 4
+extraction_radii = 60.0 80.0 100.0 120.0
+extraction_levels = 2 2 1 1
+num_points_phi = 24
+num_points_theta = 37
+num_modes = 2
+modes = 2 2 # l m for spherical harmonics
+        4 4
+
+# integral_file_prefix = "Weyl4_mode_"
+
+# write_extraction = 0
+# extraction_subpath = "data/extraction" # directory for 'write_extraction = 1'
+# extraction_file_prefix = "Weyl4_extraction_"
+
+#################################################
+# Apparent Horizon Finder parameters
+
+AH_activate = 1
+AH_num_ranks = 65
+AH_num_points_u = 65
+AH_num_points_v = 48
+# AH_solve_interval = 1
+# AH_print_interval = 1
+# AH_track_center = true
+# AH_predict_origin = true
+# AH_level_to_run = 0
+# AH_start_time = 0.
+# AH_give_up_time = -1.
+# AH_merger_search_factor = 1.
+# AH_merger_pre_factor = 1.
+# AH_allow_re_attempt = 0
+# AH_max_fails_after_lost = -1
+# AH_verbose = 1
+# AH_print_geometry_data = 0
+# AH_re_solve_at_restart = 0
+# AH_stop_if_max_fails = 0
+# AH_expansion_radius_power = 1.
+
+# AH_1_initial_guess = 0.3
+# AH_2_initial_guess = 0.3
+
+# AH_expansion_radius_power = 1.
+
+# AH_num_extra_vars = 2
+# AH_extra_vars = chi d1_Ham d2_A11
+
+AH_set_origins_to_punctures = 1
+
+# AH_coords_subpath = "data/coords"
+# AH_stats_prefix = "stats_AH"
+# AH_coords_prefix = "coords_AH"
+
+#################################################
+# Two Punctures parameters
+
+# Main BH params
+# Either calculate target masses or set bare masses explicitly below
+TP_calculate_target_masses = true
+TP_target_mass_plus = 0.5
+TP_target_mass_minus = 0.5
+# TP_adm_tol = 1e-10
+# TP_mass_plus = 0.48847892320123
+# TP_mass_minus = 0.48847892320123
+# offset in x direction (or z if TP_swap_xz set true)
+TP_offset_plus = 6.10679
+TP_offset_minus = -6.10679
+#TP_swap_xz = false
+TP_momentum_plus = -0.000510846 0.0841746 0.0
+TP_momentum_minus = 0.000510846 -0.0841746 0.0
+TP_spin_plus = 0.0 0.0 0.0
+TP_spin_minus = 0.0 0.0 0.0
+
+# Solver params
+# TP_npoints_A = 30
+# TP_npoints_B = 30
+# TP_npoints_phi = 16;
+# TP_Newton_tol = 1e-10
+# TP_Newton_maxit = 5
+TP_epsilon = 1e-6
+# TP_Tiny = 0.0
+# TP_Extend_Radius = 0.0
+
+# Initial data params
+TP_use_spectral_interpolation = true
+TP_initial_lapse = psi^n
+TP_initial_lapse_psi_exponent = -2.0
+
+# Debug output
+# TP_do_residuum_debug_output = false
+# TP_do_initial_debug_output = false
+
+#################################################

--- a/Examples/BinaryBH/params_TP_64.txt
+++ b/Examples/BinaryBH/params_TP_64.txt
@@ -71,7 +71,7 @@ max_level = 9 # There are (max_level+1) grids, so min is zero
 # Need one for each level except the top one, ie max_level items
 # Generally you do not need to regrid frequently on every level
 # Level Regridding: 0   1   2   3   4   5   6   7   8
-regrid_interval =   0   0   0   64  64  64  64  64  64
+regrid_interval =   0   0   1   0   0   0   0   0   0
 regrid_threshold = 0.05
 
 # Max and min box sizes
@@ -128,7 +128,7 @@ stop_time = 2200.0
 # max_steps = 100
 
 # Spatial derivative order (only affects CCZ4 RHS)
-max_spatial_derivative_order = 4 # can be 4 or 6
+max_spatial_derivative_order = 6 # can be 4 or 6
 
 nan_check = 1
 
@@ -151,6 +151,7 @@ covariantZ4 = 1 # 0: keep kappa1; 1 [default]: replace kappa1 -> kappa1/lapse
 
 # coefficient for KO numerical dissipation
 sigma = 1.0
+rescale_sigma = 1
 
 track_punctures = 1
 puncture_tracking_level = 5
@@ -165,19 +166,13 @@ puncture_tracking_level = 5
 
 # extraction_center = 256 256 256 # defaults to center
 activate_extraction = 1
-num_extraction_radii = 2
-extraction_radii = 50.0 100.0
-extraction_levels = 2 1
+num_extraction_radii = 4
+extraction_radii = 60.0 80.0 100.0 120.0
+extraction_levels = 2 2 1 1
 num_points_phi = 24
 num_points_theta = 37
-num_modes = 8
-modes = 2 0 # l m for spherical harmonics
-        2 1
-        2 2
-        4 0
-        4 1
-        4 2
-        4 3
+num_modes = 2
+modes = 2 2 # l m for spherical harmonics
         4 4
 
 # integral_file_prefix = "Weyl4_mode_"

--- a/Source/BoxUtils/FourthOrderDerivatives.hpp
+++ b/Source/BoxUtils/FourthOrderDerivatives.hpp
@@ -379,7 +379,7 @@ class FourthOrderDerivatives
 
     template <class data_t, template <typename> class vars_t>
     void add_dissipation(vars_t<data_t> &vars, const Cell<data_t> &current_cell,
-                         const double factor, const int direction) const
+                         const data_t factor, const int direction) const
     {
         const int stride =
             current_cell.get_box_pointers().m_in_stride[direction];
@@ -396,7 +396,7 @@ class FourthOrderDerivatives
 
     template <class data_t, template <typename> class vars_t>
     void add_dissipation(vars_t<data_t> &vars, const Cell<data_t> &current_cell,
-                         const double factor) const
+                         const data_t factor) const
     {
         const auto in_index = current_cell.get_in_index();
         vars.enum_mapping(
@@ -416,7 +416,7 @@ class FourthOrderDerivatives
 
     template <class data_t, int num_vars>
     void add_dissipation(data_t (&out)[num_vars],
-                         const Cell<data_t> &current_cell, const double factor,
+                         const Cell<data_t> &current_cell, const data_t factor,
                          const int direction) const
     {
         const int stride =

--- a/Source/BoxUtils/SixthOrderDerivatives.hpp
+++ b/Source/BoxUtils/SixthOrderDerivatives.hpp
@@ -443,7 +443,7 @@ class SixthOrderDerivatives
 
     template <class data_t, template <typename> class vars_t>
     void add_dissipation(vars_t<data_t> &vars, const Cell<data_t> &current_cell,
-                         const double factor, const int direction) const
+                         const data_t factor, const int direction) const
     {
         const int stride =
             current_cell.get_box_pointers().m_in_stride[direction];
@@ -461,7 +461,7 @@ class SixthOrderDerivatives
 
     template <class data_t, template <typename> class vars_t>
     void add_dissipation(vars_t<data_t> &vars, const Cell<data_t> &current_cell,
-                         const double factor) const
+                         const data_t factor) const
     {
         const auto in_index = current_cell.get_in_index();
         vars.enum_mapping(
@@ -482,7 +482,7 @@ class SixthOrderDerivatives
 
     template <class data_t>
     void add_dissipation(data_t (&out)[NUM_VARS],
-                         const Cell<data_t> &current_cell, const double factor,
+                         const Cell<data_t> &current_cell, const data_t factor,
                          const int direction) const
     {
         const int stride =

--- a/Source/CCZ4/CCZ4RHS.hpp
+++ b/Source/CCZ4/CCZ4RHS.hpp
@@ -85,7 +85,7 @@ class CCZ4RHS
         double a_dx,                  //!< The grid spacing
         double a_sigma,               //!< Kreiss-Oliger dissipation coefficient
         int a_formulation = USE_CCZ4, //!< Switches between CCZ4, BSSN,...
-        int a_rescale_sigma = 0,      //!< Allows a space dependent KO coefficient
+        int a_rescale_sigma = 0, //!< Allows a space dependent KO coefficient
         double a_cosmological_constant = 0 //!< Value of the cosmological const.
     );
 

--- a/Source/CCZ4/CCZ4RHS.hpp
+++ b/Source/CCZ4/CCZ4RHS.hpp
@@ -74,6 +74,7 @@ class CCZ4RHS
     const gauge_t m_gauge;   //!< Class to compute gauge in rhs_equation
     const double m_sigma;    //!< Coefficient for Kreiss-Oliger dissipation
     int m_formulation;
+    int m_rescale_sigma;
     double m_cosmological_constant;
     const deriv_t m_deriv;
 
@@ -84,6 +85,7 @@ class CCZ4RHS
         double a_dx,                  //!< The grid spacing
         double a_sigma,               //!< Kreiss-Oliger dissipation coefficient
         int a_formulation = USE_CCZ4, //!< Switches between CCZ4, BSSN,...
+        int a_rescale_sigma = 0,      //!< Allows a space dependent KO coefficient
         double a_cosmological_constant = 0 //!< Value of the cosmological const.
     );
 

--- a/Source/CCZ4/CCZ4RHS.impl.hpp
+++ b/Source/CCZ4/CCZ4RHS.impl.hpp
@@ -49,7 +49,10 @@ void CCZ4RHS<gauge_t, deriv_t>::compute(Cell<data_t> current_cell) const
     Vars<data_t> rhs;
     rhs_equation(rhs, vars, d1, d2, advec);
 
-    m_deriv.add_dissipation(rhs, current_cell, m_sigma);
+    // rescale sigma with lapse so that it is zero near puncture
+    auto sigma_c = this->m_sigma * pow(vars.lapse, 6.0);
+
+    m_deriv.add_dissipation(rhs, current_cell, sigma_c);
 
     current_cell.store_vars(rhs); // Write the rhs into the output FArrayBox
 }

--- a/Source/CCZ4/CCZ4RHS.impl.hpp
+++ b/Source/CCZ4/CCZ4RHS.impl.hpp
@@ -17,7 +17,8 @@
 template <class gauge_t, class deriv_t>
 inline CCZ4RHS<gauge_t, deriv_t>::CCZ4RHS(
     CCZ4_params_t<typename gauge_t::params_t> a_params, double a_dx,
-    double a_sigma, int a_formulation, int a_rescale_sigma, double a_cosmological_constant)
+    double a_sigma, int a_formulation, int a_rescale_sigma,
+    double a_cosmological_constant)
     : m_params(a_params), m_gauge(a_params), m_sigma(a_sigma),
       m_formulation(a_formulation), m_rescale_sigma(a_rescale_sigma),
       m_cosmological_constant(a_cosmological_constant), m_deriv(a_dx)

--- a/Source/GRChomboCore/SimulationParametersBase.hpp
+++ b/Source/GRChomboCore/SimulationParametersBase.hpp
@@ -56,6 +56,7 @@ class SimulationParametersBase : public ChomboParameters
 
         // Dissipation
         pp.load("sigma", sigma, 0.1);
+        pp.load("rescale_sigma", rescale_sigma, 0);
 
         // Nan Check and min chi and lapse values
         pp.load("nan_check", nan_check, true);
@@ -309,6 +310,8 @@ class SimulationParametersBase : public ChomboParameters
 
   public:
     double sigma; // Kreiss-Oliger dissipation parameter
+
+    int rescale_sigma;
 
     bool nan_check;
 

--- a/Source/Matter/MatterCCZ4RHS.hpp
+++ b/Source/Matter/MatterCCZ4RHS.hpp
@@ -89,8 +89,7 @@ class MatterCCZ4RHS : public CCZ4RHS<gauge_t, deriv_t>
     */
     MatterCCZ4RHS(matter_t a_matter, params_t a_params, double a_dx,
                   double a_sigma, int a_formulation = CCZ4RHS<>::USE_CCZ4,
-                  double a_G_Newton = 1.0,
-                  int a_rescale_sigma = 0);
+                  double a_G_Newton = 1.0, int a_rescale_sigma = 0);
 
     //!  The compute member which calculates the RHS at each point in the box
     //!  \sa matter_rhs_equation()

--- a/Source/Matter/MatterCCZ4RHS.hpp
+++ b/Source/Matter/MatterCCZ4RHS.hpp
@@ -89,7 +89,8 @@ class MatterCCZ4RHS : public CCZ4RHS<gauge_t, deriv_t>
     */
     MatterCCZ4RHS(matter_t a_matter, params_t a_params, double a_dx,
                   double a_sigma, int a_formulation = CCZ4RHS<>::USE_CCZ4,
-                  double a_G_Newton = 1.0);
+                  double a_G_Newton = 1.0,
+                  int a_rescale_sigma = 0);
 
     //!  The compute member which calculates the RHS at each point in the box
     //!  \sa matter_rhs_equation()
@@ -110,6 +111,7 @@ class MatterCCZ4RHS : public CCZ4RHS<gauge_t, deriv_t>
     // Class members
     matter_t my_matter;      //!< The matter object, e.g. a scalar field.
     const double m_G_Newton; //!< Newton's constant, set to one by default.
+    int m_rescale_sigma;     //!< Allows a space dependent KO coefficient.
 };
 
 #include "MatterCCZ4RHS.impl.hpp"

--- a/Source/Matter/MatterCCZ4RHS.impl.hpp
+++ b/Source/Matter/MatterCCZ4RHS.impl.hpp
@@ -14,10 +14,13 @@
 template <class matter_t, class gauge_t, class deriv_t>
 MatterCCZ4RHS<matter_t, gauge_t, deriv_t>::MatterCCZ4RHS(
     matter_t a_matter, CCZ4_params_t<typename gauge_t::params_t> a_params,
-    double a_dx, double a_sigma, int a_formulation, double a_G_Newton, int a_rescale_sigma)
-    : CCZ4RHS<gauge_t, deriv_t>(a_params, a_dx, a_sigma, a_formulation, a_rescale_sigma,
+    double a_dx, double a_sigma, int a_formulation, double a_G_Newton,
+    int a_rescale_sigma)
+    : CCZ4RHS<gauge_t, deriv_t>(a_params, a_dx, a_sigma, a_formulation,
+                                a_rescale_sigma,
                                 0.0 /*No cosmological constant*/),
-      my_matter(a_matter), m_G_Newton(a_G_Newton), m_rescale_sigma(a_rescale_sigma)
+      my_matter(a_matter), m_G_Newton(a_G_Newton),
+      m_rescale_sigma(a_rescale_sigma)
 {
 }
 

--- a/Source/Matter/MatterCCZ4RHS.impl.hpp
+++ b/Source/Matter/MatterCCZ4RHS.impl.hpp
@@ -43,8 +43,11 @@ void MatterCCZ4RHS<matter_t, gauge_t, deriv_t>::compute(
     // add evolution of matter fields themselves
     my_matter.add_matter_rhs(matter_rhs, matter_vars, d1, d2, advec);
 
+    // rescale sigma with lapse so that it is zero near black holes
+    auto sigma_c = this->m_sigma * pow(matter_vars.lapse, 6.0);
+
     // Add dissipation to all terms
-    this->m_deriv.add_dissipation(matter_rhs, current_cell, this->m_sigma);
+    this->m_deriv.add_dissipation(matter_rhs, current_cell, sigma_c);
 
     // Write the rhs into the output FArrayBox
     current_cell.store_vars(matter_rhs);

--- a/Source/TaggingCriteria/TwoPuncturesBoxExtractionTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/TwoPuncturesBoxExtractionTaggingCriterion.hpp
@@ -24,12 +24,15 @@ class TwoPuncturesBoxExtractionTaggingCriterion
     const std::vector<std::array<double, CH_SPACEDIM>> &m_puncture_coords;
 
   public:
-    TwoPuncturesBoxExtractionTaggingCriterion(const double dx, const int a_level,
-                               const int a_max_level, const spherical_extraction_params_t a_params,
-                               const std::vector<std::array<double, CH_SPACEDIM>> &a_puncture_coords,
-        const bool activate_extraction = false, const std::vector<double> a_puncture_masses = {0.5, 0.5})
-        : m_dx(dx), m_level(a_level), m_max_level(a_max_level), m_params(a_params),
-          m_activate_extraction(activate_extraction), m_puncture_masses(a_puncture_masses),
+    TwoPuncturesBoxExtractionTaggingCriterion(
+        const double dx, const int a_level, const int a_max_level,
+        const spherical_extraction_params_t a_params,
+        const std::vector<std::array<double, CH_SPACEDIM>> &a_puncture_coords,
+        const bool activate_extraction = false,
+        const std::vector<double> a_puncture_masses = {0.5, 0.5})
+        : m_dx(dx), m_level(a_level), m_max_level(a_max_level),
+          m_params(a_params), m_activate_extraction(activate_extraction),
+          m_puncture_masses(a_puncture_masses),
           m_puncture_coords(a_puncture_coords){};
 
     template <class data_t> void compute(Cell<data_t> current_cell) const
@@ -37,9 +40,11 @@ class TwoPuncturesBoxExtractionTaggingCriterion
         data_t criterion = 0.0;
 
         double puncture_separation_squared = 0.0;
-        FOR(i) {
-           double displacement = m_puncture_coords[0][i] - m_puncture_coords[1][i];
-           puncture_separation_squared += displacement * displacement;
+        FOR(i)
+        {
+            double displacement =
+                m_puncture_coords[0][i] - m_puncture_coords[1][i];
+            puncture_separation_squared += displacement * displacement;
         }
         // make sure the inner part is regridded around the horizon
         // take L as the length of full grid, so tag inner 1/2
@@ -59,37 +64,46 @@ class TwoPuncturesBoxExtractionTaggingCriterion
             for (int ipuncture = 0; ipuncture < m_puncture_masses.size();
                  ++ipuncture)
             {
-               // where am i?
-               const Coordinates<data_t> coords(current_cell, m_dx,
+                // where am i?
+                const Coordinates<data_t> coords(current_cell, m_dx,
                                                  m_puncture_coords[ipuncture]);
-               const data_t max_abs_xy = simd_max(abs(coords.x), abs(coords.y));
-               const data_t max_abs_xyz = simd_max(max_abs_xy, abs(coords.z));
-               auto regrid = simd_compare_lt(max_abs_xyz, 2.5 * factor * m_puncture_masses[ipuncture]);
-               criterion = simd_conditional(regrid, 100.0, criterion);
-            // if (m_level < m_max_level){
-            //     const Coordinates<data_t> coords_c(current_cell, m_dx,
-            //                                         m_params.center);
-            //     const data_t rho = sqrt(coords_c.x * coords_c.x + coords_c.y * coords_c.y);
-            //     auto regrid = simd_compare_lt(
-            //                 rho, 0.7 * factor * sqrt(puncture_separation_squared)) &&
-            //         simd_compare_lt(abs(coords_c.z), 2.5 * m_puncture_masses[ipuncture]);
-            //     // pout() << sqrt(puncture_separation_squared) << endl;
-            //     criterion = simd_conditional(regrid, 100.0, criterion);
-            //     }
+                const data_t max_abs_xy =
+                    simd_max(abs(coords.x), abs(coords.y));
+                const data_t max_abs_xyz = simd_max(max_abs_xy, abs(coords.z));
+                auto regrid = simd_compare_lt(
+                    max_abs_xyz, 2.5 * factor * m_puncture_masses[ipuncture]);
+                criterion = simd_conditional(regrid, 100.0, criterion);
+                // if (m_level < m_max_level){
+                //     const Coordinates<data_t> coords_c(current_cell, m_dx,
+                //                                         m_params.center);
+                //     const data_t rho = sqrt(coords_c.x * coords_c.x +
+                //     coords_c.y * coords_c.y); auto regrid = simd_compare_lt(
+                //                 rho, 0.7 * factor *
+                //                 sqrt(puncture_separation_squared)) &&
+                //         simd_compare_lt(abs(coords_c.z), 2.5 *
+                //         m_puncture_masses[ipuncture]);
+                //     // pout() << sqrt(puncture_separation_squared) << endl;
+                //     criterion = simd_conditional(regrid, 100.0, criterion);
+                //     }
             }
         }
-        else {
+        else
+        {
             // where am i?
             std::array<double, CH_SPACEDIM> puncture_centre;
-            FOR(i) puncture_centre[i] = 0.5 * (m_puncture_coords[0][i] + m_puncture_coords[1][i]);
-            const Coordinates<data_t> coords(current_cell, m_dx, puncture_centre);
+            FOR(i)
+            puncture_centre[i] =
+                0.5 * (m_puncture_coords[0][i] + m_puncture_coords[1][i]);
+            const Coordinates<data_t> coords(current_cell, m_dx,
+                                             puncture_centre);
             const data_t max_abs_xy = simd_max(abs(coords.x), abs(coords.y));
             const data_t max_abs_xyz = simd_max(max_abs_xy, abs(coords.z));
-            auto regrid = simd_compare_lt(max_abs_xyz, 1.5 * factor * sum_masses);
+            auto regrid =
+                simd_compare_lt(max_abs_xyz, 1.5 * factor * sum_masses);
             criterion = simd_conditional(regrid, 100.0, criterion);
         }
 
-         // if extracting weyl data at a given radius, enforce a given resolution
+        // if extracting weyl data at a given radius, enforce a given resolution
         // there
         if (m_activate_extraction)
         {

--- a/Source/TaggingCriteria/TwoPuncturesBoxExtractionTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/TwoPuncturesBoxExtractionTaggingCriterion.hpp
@@ -1,0 +1,122 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef TWOPUNCTURESBOXEXTRACTIONTAGGINGCRITERION_HPP_
+#define TWOPUNCTURESBOXEXTRACTIONTAGGINGCRITERION_HPP_
+
+#include "Cell.hpp"
+#include "Coordinates.hpp"
+#include "DimensionDefinitions.hpp"
+#include "SphericalExtraction.hpp"
+#include "Tensor.hpp"
+
+class TwoPuncturesBoxExtractionTaggingCriterion
+{
+  protected:
+    const double m_dx;
+    const int m_level;
+    const int m_max_level;
+    const spherical_extraction_params_t m_params;
+    const bool m_activate_extraction;
+    const std::vector<double> m_puncture_masses;
+    const std::vector<std::array<double, CH_SPACEDIM>> &m_puncture_coords;
+
+  public:
+    TwoPuncturesBoxExtractionTaggingCriterion(
+        const double dx, const int a_level, const int a_max_level,
+        const spherical_extraction_params_t a_params,
+        const std::vector<std::array<double, CH_SPACEDIM>> &a_puncture_coords,
+        const bool activate_extraction = false,
+        const std::vector<double> a_puncture_masses = {0.5, 0.5})
+        : m_dx(dx), m_level(a_level), m_max_level(a_max_level),
+          m_params(a_params), m_activate_extraction(activate_extraction),
+          m_puncture_masses(a_puncture_masses),
+          m_puncture_coords(a_puncture_coords){};
+
+    template <class data_t> void compute(Cell<data_t> current_cell) const
+    {
+        data_t criterion = 0.0;
+
+        double puncture_separation_squared = 0.0;
+        FOR(i)
+        {
+            double displacement =
+                m_puncture_coords[0][i] - m_puncture_coords[1][i];
+            puncture_separation_squared += displacement * displacement;
+        }
+        // make sure the inner part is regridded around the horizon
+        // take L as the length of full grid, so tag inner 1/2
+        // of it, which means inner \pm L/4
+        // we want each level to be double the innermost one in size
+        const double factor = pow(2.0, m_max_level - m_level - 1);
+        double sum_masses = m_puncture_masses[0] + m_puncture_masses[1];
+
+        if (puncture_separation_squared > 2.25 * sum_masses * sum_masses)
+        {
+            // loop over puncture masses
+            for (int ipuncture = 0; ipuncture < m_puncture_masses.size();
+                 ++ipuncture)
+            {
+                // where am i?
+                const Coordinates<data_t> coords(current_cell, m_dx,
+                                                 m_puncture_coords[ipuncture]);
+                const data_t max_abs_xy =
+                    simd_max(abs(coords.x), abs(coords.y));
+                const data_t max_abs_xyz = simd_max(max_abs_xy, abs(coords.z));
+                auto regrid = simd_compare_lt(
+                    max_abs_xyz, 2.5 * factor * m_puncture_masses[ipuncture]);
+                criterion = simd_conditional(regrid, 100.0, criterion);
+            }
+        }
+        else if (puncture_separation_squared < 2.25 * sum_masses * sum_masses &&
+                 m_level == m_max_level - 1)
+        {
+            criterion = 0;
+        }
+        else if (puncture_separation_squared < 2.25 * sum_masses * sum_masses &&
+                 m_level == m_max_level - 2)
+        {
+            // where am i?
+            std::array<double, CH_SPACEDIM> puncture_centre;
+            FOR(i)
+            puncture_centre[i] =
+                0.5 * (m_puncture_coords[0][i] + m_puncture_coords[1][i]);
+            const Coordinates<data_t> coords(current_cell, m_dx,
+                                             puncture_centre);
+            const data_t max_abs_xy = simd_max(abs(coords.x), abs(coords.y));
+            const data_t max_abs_xyz = simd_max(max_abs_xy, abs(coords.z));
+            auto regrid =
+                simd_compare_lt(max_abs_xyz, 2.5 * factor * sum_masses);
+            criterion = simd_conditional(regrid, 100.0, criterion);
+        }
+
+        // if extracting weyl data at a given radius, enforce a given resolution
+        // there
+        if (m_activate_extraction)
+        {
+            for (int iradius = 0; iradius < m_params.num_extraction_radii;
+                 ++iradius)
+            {
+                // regrid if within extraction level and not at required
+                // refinement
+                if (m_level < m_params.extraction_levels[iradius])
+                {
+                    const Coordinates<data_t> coords(current_cell, m_dx,
+                                                     m_params.center);
+                    const data_t r = coords.get_radius();
+                    // add a 20% buffer to extraction zone so not too near to
+                    // boundary
+                    auto regrid = simd_compare_lt(
+                        r, 1.2 * m_params.extraction_radii[iradius]);
+                    criterion = simd_conditional(regrid, 100.0, criterion);
+                }
+            }
+        }
+        // Write back into the flattened Chombo box
+        current_cell.store_vars(criterion, 0);
+    }
+};
+
+#endif /* TWOPUNCTURESBOXEXTRACTIONTAGGINGCRITERION_HPP_ */

--- a/Tests/DerivativeUnitTests/DerivativeTestsCompute.hpp
+++ b/Tests/DerivativeUnitTests/DerivativeTestsCompute.hpp
@@ -46,7 +46,8 @@ template <class deriv_t> class DerivativeTestsCompute
 
         Vars<data_t> out_diss;
         VarsTools::assign(out_diss, 0.);
-        m_deriv.add_dissipation(out_diss, current_cell, 1.0);
+        data_t sigma = 1.0;
+        m_deriv.add_dissipation(out_diss, current_cell, sigma);
 
         Tensor<1, data_t> shift_down = {-2., 0., -3.};
         const auto out_advec_down =


### PR DESCRIPTION
This PR updates the BinaryBH example, whose accuracy has always been highly sensitive to the adaptive mesh refinement. The primary cause of the inaccurate phase evolution of the binary was an artificial growth of the black hole masses, which only converges to zero at very high resolutions. Here we have identified that this mass growth is very sensitive to the Kreiss-Oliger (KO). For example, the growth rate is worse for larger `sigma` coefficients and the waveforms are more accurate for small values of `sigma`. However, choosing small `sigma` does not remove high frequency errors near the extraction spheres, which result in noisy waveforms. Given the dependence of the KO on the timestep Δt, we now introduce a space-dependent coefficient that turns off the KO near the punctures. For now, we have found that `lapse^6 * sigma` yields optimal results when starting with a pre-collapsed lapse. However, one might want to update this in the future to `lapse^4 * chi * sigma` if the lapse starts from 1. This PR also implements a tagging criterion closer to the standard 'Moving Boxes' approach, and introduces default params.txt files at two resolutions: N=48, which runs at 100 M/hr on 800 CPUs, and N=64, which runs at 50 M/hr on 1500 CPUs. Hence, these setups generate relatively accurate waveforms in 1 and 2 days, with errors of approximately 1% and 0.5%, respectively. These updates seem to allow us to achieve similar accuracies to the waveforms in [arXiv:2112.10567](https://arxiv.org/abs/2112.10567), but with lower resolution (and thus faster) simulations.

![image](https://github.com/user-attachments/assets/145be77e-13b1-4b57-8b6d-dadafc6e2c31)
