### PR TITLE
Add make defs local file for LUMI-C system

### DIFF
--- a/InstallNotes/MakeDefsLocalExamples/LUMIC.Make.defs.local
+++ b/InstallNotes/MakeDefsLocalExamples/LUMIC.Make.defs.local
@@ -1,0 +1,15 @@
+# Required modules:
+# module load PrgEnv-gnu cray-hdf5-parallel/1.12.2.9
+DIM           = 3
+CXX           = g++
+FC            = gfortran 
+DEBUG         = FALSE
+OPT           = TRUE
+MPI           = TRUE
+OMP           = TRUE
+MPICXX        = mpicxx
+HDFINCFLAGS    = -I${HDF5_DIR}/include
+HDFLIBFLAGS    = -L${HDF5_DIR}/lib -lhdf5 -lz
+HDFMPIINCFLAGS = -I${HDF5_DIR}/include
+HDFMPILIBFLAGS = -L${HDF5_DIR}/lib -lhdf5 -lz
+syslibflags    = -L/opt/cray/pe/libsci/24.03.0/GNU/12.3/x86_64/lib -lsci_gnu


### PR DESCRIPTION
Adding the make refs local file for LUMI-C https://docs.lumi-supercomputer.eu/hardware/lumic/ 

@areefw I think strictly you shouldn't review this as we are the same institution, but it can't break anything and it will be useful once we get access to LUMI-C, so if it looks ok I think it would be fine to merge this now. Just don't tell Miren :-)